### PR TITLE
fixes + more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Switched from `hashlib.sha1` to UUID-based identifiers without hashing
+- Switched from `hashlib.sha1` to UUID-based identifiers without hashing.
+- **BREAKING**: Renamed `--db-version` to `--sqlite-version` for clarity.
+- **BREAKING**: `--db-version` now returns the database schema version instead of SQLite version.
 - Modernized the codebase.
-- Updated dependencies to their latest versions
+- Updated dependencies to their latest versions.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `--tag` option, one or more times for multiple tags. E.g. `--tag tag1 --tag tag2`.
   - The `#` symbol in the description, one or more times. E.g. `#tag1 #tag2`.
   The description must be quoted in this case.
-  - Tags are case-sensitive.
+  - Tags are case-insensitive.
 - Querying by tags using the `--tag` option. Using multiple times will match any of the specified tags.
 - Specifying duration while adding work.
   - The `--duration` option, e.g. `--duration 1h30m` or `--duration 90m`.
-  - The `[]` symbol in the description, e.g. `[1.5h]` or `[90m]`. The description must be quoted in this case.
+  - The `[]` symbol in the description, e.g. `[1.5h]` or `[90m]`.
   - Duration is case-insensitive. Allows `h|hr|hrs|hours|m|min|mins|minutes`.
 - Querying by duration using the `--duration` option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `--tag` option, one or more times for multiple tags. E.g. `--tag tag1 --tag tag2`.
   - The `#` symbol in the description, one or more times. E.g. `#tag1 #tag2`.
   The description must be quoted in this case.
-  - Tags are case-insensitive.
+  - Tags are case-insensitive and are saved in lowercase.
 - Querying by tags using the `--tag` option. Using multiple times will match any of the specified tags.
 - Specifying duration while adding work.
   - The `--duration` option, e.g. `--duration 1h30m` or `--duration 90m`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -540,3 +540,19 @@ def test_cli_duration_filter(
         assert "Date:" in result_fetch.output
     else:
         assert "Nothing to show" in result_fetch.output
+
+
+@pytest.mark.parametrize(
+    "filter_flag",
+    [
+        ["--duration", "=>3h"],
+        ["--duration", "3hors"],
+        ["--duration", "3h<"],
+        ["--duration", "==60m"],
+        ["--duration", "[3h]"],
+        ["--duration", "3x"],
+    ],
+)
+def test_invalid_duration_filter(runner: CliRunner, filter_flag: list[str]) -> None:
+    result = runner.invoke(cli.what, ["--no-page", *filter_flag])
+    assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -280,7 +280,14 @@ def test_db_vacuum(runner: CliRunner, options: list[str]) -> None:
 def test_db_version(runner: CliRunner, options: list[str]) -> None:
     result = runner.invoke(cli.main, options)
     assert result.exit_code == 0
-    assert result.output.startswith("SQLite version:")
+    assert result.output.startswith("Database schema version: ")
+
+
+@pytest.mark.parametrize("options", [["--sqlite-version"]])
+def test_sqlite_version(runner: CliRunner, options: list[str]) -> None:
+    result = runner.invoke(cli.main, options)
+    assert result.exit_code == 0
+    assert result.output.startswith("SQLite version: ")
 
 
 @pytest.mark.parametrize(
@@ -543,16 +550,14 @@ def test_cli_duration_filter(
 
 
 @pytest.mark.parametrize(
-    "filter_flag",
+    "invalid_filter_flag",
     [
         ["--duration", "=>3h"],
         ["--duration", "3hors"],
         ["--duration", "3h<"],
-        ["--duration", "==60m"],
-        ["--duration", "[3h]"],
         ["--duration", "3x"],
     ],
 )
-def test_invalid_duration_filter(runner: CliRunner, filter_flag: list[str]) -> None:
-    result = runner.invoke(cli.what, ["--no-page", *filter_flag])
+def test_invalid_duration_filter(runner: CliRunner, invalid_filter_flag: list[str]) -> None:
+    result = runner.invoke(cli.what, ["--no-page", *invalid_filter_flag])
     assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -450,7 +450,7 @@ def test_weird_tag_parsing(runner: CliRunner, input_text: str, expected_tags: se
     [
         ("working on #devtools", ["--tag", "devtools"], True),
         ("#in-progress cleanup", ["--tag", "in-progress"], True),
-        ("writing code #DEV", ["--tag", "dev"], False),  # case-insensitive
+        ("writing code #DEV", ["--tag", "dev"], True),  # case-insensitive
         ("refactoring #code_review", ["--tag", "code_review"], True),
         ("invalid ##doubletag", ["--tag", "doubletag"], True),
         ("emoji #🔥", ["--tag", "🔥"], False),

--- a/workedon/cli.py
+++ b/workedon/cli.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Callable
-import warnings
 
 import click
 from click_default_group import DefaultGroup
@@ -14,7 +14,12 @@ from .models import DB_PATH, get_db_user_version, init_db, truncate_all_tables
 from .utils import add_options, load_settings
 from .workedon import fetch_tags, fetch_work, save_work
 
-warnings.filterwarnings("ignore")
+# Only ignore warnings if not in debug mode
+if not os.environ.get("WORKEDON_DEBUG"):
+    import warnings
+
+    warnings.filterwarnings("ignore")
+
 CONTEXT_SETTINGS: dict[str, list[str]] = {"help_option_names": ["-h", "--help"]}
 
 # settings

--- a/workedon/cli.py
+++ b/workedon/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Callable
+import warnings
 
 import click
 from click_default_group import DefaultGroup
@@ -13,6 +14,7 @@ from .models import DB_PATH, get_db_user_version, init_db, truncate_all_tables
 from .utils import add_options, load_settings
 from .workedon import fetch_tags, fetch_work, save_work
 
+warnings.filterwarnings("ignore")
 CONTEXT_SETTINGS: dict[str, list[str]] = {"help_option_names": ["-h", "--help"]}
 
 # settings

--- a/workedon/cli.py
+++ b/workedon/cli.py
@@ -9,7 +9,7 @@ from click_default_group import DefaultGroup
 
 from ._version import __version__ as _ver
 from .conf import CONF_PATH, settings
-from .models import DB_PATH, init_db, truncate_all_tables
+from .models import DB_PATH, get_db_user_version, init_db, truncate_all_tables
 from .utils import add_options, load_settings
 from .workedon import fetch_tags, fetch_work, save_work
 
@@ -133,6 +133,15 @@ main_options: list[Callable[..., Any]] = [
     default=False,
     show_default=True,
     hidden=True,
+    help="Print the version of the current database schema.",
+)
+@click.option(
+    "--sqlite-version",
+    is_flag=True,
+    required=False,
+    default=False,
+    show_default=True,
+    hidden=True,
     help="Print the version of SQLite being used.",
 )
 @click.option(
@@ -171,6 +180,7 @@ def main(
     print_settings: bool,
     list_tags: bool,
     db_version: bool,
+    sqlite_version: bool,
     print_db_path: bool,
     vacuum_db: bool,
     truncate_db: bool,
@@ -210,6 +220,10 @@ def main(
                 truncate_all_tables()
             click.echo("Deletion successful.")
     elif db_version:
+        with init_db() as db:
+            version = get_db_user_version(db)
+            click.echo(f"Database schema version: {version}")
+    elif sqlite_version:
         with init_db() as db:
             server_version = ".".join(str(num) for num in db.server_version)
             click.echo(f"SQLite version: {server_version}")

--- a/workedon/models.py
+++ b/workedon/models.py
@@ -153,7 +153,7 @@ def truncate_all_tables(**options: dict[str, Any]) -> None:
         model.truncate_table(**options)
 
 
-def _get_db_user_version(database: SqliteDatabase) -> int:
+def get_db_user_version(database: SqliteDatabase) -> int:
     """
     Return the current PRAGMA user_version from an open connection.
     """
@@ -200,15 +200,15 @@ def _apply_pending_migrations(database: SqliteDatabase) -> None:
     - Else if it's 1, run v1 -> v2.
     """
     try:
-        existing_version = _get_db_user_version(database)
+        existing_version = get_db_user_version(database)
         # fresh new install
         if existing_version == 0:
             _create_initial_tables(database)
-            existing_version = _get_db_user_version(database)
+            existing_version = get_db_user_version(database)
         # v1
         if existing_version < 2:
             _migrate_v1_to_v2(database)
-            existing_version = _get_db_user_version(database)
+            existing_version = get_db_user_version(database)
         # Add more future versions here...
         # sanity check
         if existing_version != CURRENT_DB_VERSION:

--- a/workedon/models.py
+++ b/workedon/models.py
@@ -204,10 +204,19 @@ def _apply_pending_migrations(database: SqliteDatabase) -> None:
         # fresh new install
         if existing_version == 0:
             _create_initial_tables(database)
-            return
+            existing_version = _get_db_user_version(database)
         # v1
         if existing_version < 2:
             _migrate_v1_to_v2(database)
+            existing_version = _get_db_user_version(database)
+        # Add more future versions here...
+        # sanity check
+        if existing_version != CURRENT_DB_VERSION:
+            msg = (
+                f"Database schema mismatch after migration: expected {CURRENT_DB_VERSION},"
+                f" found {existing_version}"
+            )
+            raise DBInitializationError(extra_detail=msg)
     except OperationalError as e:
         raise DBInitializationError(extra_detail=str(e)) from e
 

--- a/workedon/workedon.py
+++ b/workedon/workedon.py
@@ -32,6 +32,8 @@ def save_work(work: tuple[str, ...], tags_opt: tuple[str, ...], duration_opt: st
     work_text, dt, duration, tags = parser.parse(work_desc)
     if tags_opt:
         tags.update(set(tags_opt))
+    tags = {tag.lower() for tag in tags}
+
     if duration_opt:
         minutes = parser.parse_duration(f"[{duration_opt.strip()}]")
         if minutes is not None:
@@ -146,7 +148,8 @@ def fetch_work(
     else:
         # tag
         if tags:
-            work_set = work_set.join(WorkTag).join(Tag).where(Tag.name.in_(tags)).distinct()
+            normalized = [t.lower() for t in tags]
+            work_set = work_set.join(WorkTag).join(Tag).where(Tag.name.in_(normalized)).distinct()
         # duration
         if duration:
             # Match optional comparison operator and value (e.g., '>=3h', '<= 45min', '2h')

--- a/workedon/workedon.py
+++ b/workedon/workedon.py
@@ -153,7 +153,7 @@ def fetch_work(
         # duration
         if duration:
             # Match optional comparison operator and value (e.g., '>=3h', '<= 45min', '2h')
-            match = re.match(r"\s*(<=|>=|<|>|=)?\s*(.+)", duration)
+            match = re.match(r"\s*(==|<=|>=|=|<|>)?\s*(.+)", duration)
             if not match:
                 raise CannotFetchWorkError(extra_detail="Invalid duration filter")
             comp_op, dur_str = match.groups()


### PR DESCRIPTION
Clarity in Version Reporting: It renames the --db-version CLI option to --sqlite-version to specifically report the underlying SQLite library version. The --db-version option is repurposed to report the application's database schema version, which is a breaking change.
Tag Handling: Tags are now treated as case-insensitive when saving and querying.
Duration Filter Validation: Adds validation and tests for invalid inputs when filtering work entries by duration.
Database Migration Sanity Check: Introduces a check after database migrations to ensure the schema version in the database matches the expected current version defined in the code.
Testing: Includes new tests or updates existing ones to cover the changes mentioned above.